### PR TITLE
Skip over 500 api responses.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,11 @@ package: __package-base ## Create container
 		$(BUILDER_TAG) \
 		make __package-sbt
 
-publish: package
-	@docker tag $(PUBLISH_TAG) $(LATEST_TAG)
+__publish:
 	@docker push $(PUBLISH_TAG)
+
+publish: package __publish
+	@docker tag $(PUBLISH_TAG) $(LATEST_TAG)
 	@docker push $(LATEST_TAG)
 
 base-tag: ## Used by sbt to get base image for docker.

--- a/src/main/scala/com/meetup/jirastats/JiraHandler.scala
+++ b/src/main/scala/com/meetup/jirastats/JiraHandler.scala
@@ -7,7 +7,7 @@ import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
 trait JiraHandler {
-  def issues(startAt: Option[Int] = None): Future[Issues]
+  def issues(startAt: Option[Int] = None, maxResults: Int = 50): Future[Issues]
   def epics(startAt: Option[Int] = None): Future[Issues]
   def versions(): Future[Map[String, List[JiraVersion]]]
   def close(): Unit
@@ -27,12 +27,13 @@ object JiraHandler {
 }
 
 class JiraHandlerImpl(client: JiraClient) extends JiraHandler {
-  def issues(startAt: Option[Int] = None): Future[Issues] = {
+  def issues(startAt: Option[Int] = None, maxResults: Int = 50): Future[Issues] = {
     client.search(
       Search(
         jql = "status = Closed AND resolution = Done AND createdDate > '2016-01-01'",
         startAt = startAt,
-        expand = Some(List("changelog"))
+        expand = Some(List("changelog")),
+        maxResults = Some(maxResults)
       ))
   }
 

--- a/src/main/scala/com/meetup/jirastats/WriteIssues.scala
+++ b/src/main/scala/com/meetup/jirastats/WriteIssues.scala
@@ -6,31 +6,57 @@ import com.meetup.jirastats.printer.{IO, JsonPrinter}
 import scala.annotation.tailrec
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 class WriteIssues(handler: JiraHandler, issuesWriter: IO, transitionsWriter: IO) {
 
+  sealed trait Response
+  case object Failed extends Response
+  case class Ok(nextOffset: Option[Int]) extends Response
+
   @tailrec
-  final def write(offset: Option[Int] = None): Unit = {
-    val nextOffset =
-      Try(Await.result(handler.issues(offset), 30.seconds))
-        .toOption
-        .flatMap { search =>
-          val start = search.startAt
-          val until = start + search.maxResults
-          println(s"Writing issues $start to $until of ${search.total}")
+  final def write(
+    offset: Option[Int] = None,
+    maxResults: Int = 50,
+    retry: Int = 0
+  ): Unit = {
+    val next = nextOffset(offset, maxResults)
 
-          val jiraStats = JiraIssues.fromIssues(search)
-          JsonPrinter.print(jiraStats, issuesWriter)
-          JsonPrinter.printTransitions(jiraStats, transitionsWriter)
+    next match {
+      case Ok(nextOffset) if nextOffset.isDefined =>
+        Thread.sleep(1000)
+        write(nextOffset, maxResults)
 
-          Some(search.startAt + search.maxResults)
-            .filter(_ < search.total)
-        }
+      case Failed if retry < 2 =>
+        write(offset, maxResults, retry + 1)
 
-    if (nextOffset.isDefined) {
-      Thread.sleep(1000)
-      write(nextOffset)
+      case Failed =>
+        println(s"Skipping over failed offset: $offset")
+        write(offset.map(_ + maxResults), maxResults)
+
+      case _ =>
+      // We're done
+    }
+  }
+
+  private def nextOffset(offset: Option[Int], maxResults: Int): Response = {
+    Try(Await.result(handler.issues(offset), 30.seconds)) match {
+      case Success(search) =>
+        val start = search.startAt
+        val until = start + search.maxResults
+        println(s"Writing issues $start to $until of ${search.total}")
+
+        val jiraStats = JiraIssues.fromIssues(search)
+        JsonPrinter.print(jiraStats, issuesWriter)
+        JsonPrinter.printTransitions(jiraStats, transitionsWriter)
+
+        Ok(Some(search.startAt + search.maxResults)
+          .filter(_ < search.total))
+
+      case Failure(e) =>
+        println(s"Exception occurred on offset $offset")
+        e.printStackTrace()
+        Failed
     }
   }
 }


### PR DESCRIPTION
There's a temporary issue where Jira is returning 500s for certain api calls with changlogs: https://jira.atlassian.com/browse/JRACLOUD-67458?jql=status%20in%20(Open%2C%20%22In%20Progress%22)%20AND%20text%20~%20%22API%20500%22%20ORDER%20BY%20created%20DESC

For now let's just skip over those batches and at least get the rest of what we want.